### PR TITLE
Return to origin for classes

### DIFF
--- a/ansi.py
+++ b/ansi.py
@@ -73,6 +73,22 @@ class Echo:
 class Terminal:
     def __init__(self):
         self.written_lines = 0
+        self.echo = Echo()
+
+    def prepare(self):
+        hide_cursor()
+        self.echo.switch_off()
+
+    def safe_prepare(self):
+        self.prepare()
+
+        import atexit
+        atexit.register(self.cleanup)
+
+    def cleanup(self):
+        show_cursor()
+        reset()
+        self.echo.reset()
 
     def write(self, text, *args, new_line=False, **kwargs):
         self.written_lines += text.count(LF) + new_line
@@ -90,16 +106,10 @@ class Terminal:
 
 @contextlib.contextmanager
 def terminal():
-    echo = Echo()
-    terminal = Terminal()
-
+    t = Terminal()
     try:
-        hide_cursor()
-        echo.switch_off()
-
-        yield terminal
+        t.prepare()
+        yield t
 
     finally:
-        show_cursor()
-        reset()
-        echo.reset()
+        t.cleanup()

--- a/matrix.py
+++ b/matrix.py
@@ -1,6 +1,6 @@
 import time
 
-import ansi
+from ansi import Terminal
 
 
 BLACK = 0,0,0
@@ -15,6 +15,10 @@ class Matrix():
         self.size_y = size_y
 
         self.__create_matrix()
+
+        terminal = Terminal()
+        terminal.safe_prepare()
+        self.terminal = terminal
 
         self._auto_show = auto_show
 
@@ -46,12 +50,11 @@ class Matrix():
             self.show()
 
     def show(self):
-        with ansi.terminal() as terminal:
-            for y in self.__rows():
-                for x in self.__cells():
-                    terminal.write(PIXEL, self._matrix[x][y])
-                terminal.break_line()
-            terminal.go_to_origin()
+        self.terminal.go_to_origin()
+        for y in self.__rows():
+            for x in self.__cells():
+                self.terminal.write(PIXEL, self._matrix[x][y])
+            self.terminal.break_line()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds ability to use `Terminal` object in user classes. This is convenient when terminal is reset on script exit.